### PR TITLE
fix: persist admin actions (suspend/dismiss) and update database RLS

### DIFF
--- a/src/hooks/useAdminDashboard.js
+++ b/src/hooks/useAdminDashboard.js
@@ -155,14 +155,15 @@ export function useAdminDashboard() {
       const { data, error } = await supabase
         .from('reports')
         .select(`
-          id, reason, details, created_at, reporter_id, target_user_id,
-          reporter:profiles!reports_reporter_id_fkey (
-            id, display_name
-          ),
-          target:profiles!reports_target_user_id_fkey (
-            id, display_name
-          )
-        `)
+  id, reason, details, created_at, reporter_id, target_user_id,
+  status, resolution,
+  reporter:profiles!reports_reporter_id_fkey (
+    id, display_name
+  ),
+  target:profiles!reports_target_user_id_fkey (
+    id, display_name
+  )
+`)
         .eq('type', 'profile')
         .order('created_at', { ascending: false });
 
@@ -170,10 +171,11 @@ export function useAdminDashboard() {
 
       const normalized = data.map(r => ({
         id: r.id,
-        reason: r.reason,
-        details: r.details,
-        status: 'pending',
-        reportedAt: r.created_at,
+  reason: r.reason,
+  details: r.details,
+  status: r.status ?? 'pending',       // ← reads from DB now
+  resolution: r.resolution ?? null,    // ← reads from DB now
+  reportedAt: r.created_at,
         reporter: {
           name: r.reporter?.display_name ?? 'Unknown',
           avatar: (r.reporter?.display_name?.[0] ?? 'U').toUpperCase(),


### PR DESCRIPTION
### What does this PR do?
This PR ensures that Admin actions (Suspensions and Dismissals) persist correctly in the database and survive page reloads. 

### Key Changes & Fixes
* **Database & RLS:** Updated Supabase Row Level Security (RLS) policies and table configurations so the application has the correct permissions to update user roles and report statuses.
* **Dashboard Logic:** Refined `useAdminDashboard.js` to ensure the local UI state accurately reflects the persistent database state.

### Testing Notes
* Clicked "Suspend" or "Dismiss" on a user report.
* Refreshed/reloaded the browser.
* Verified that the action persisted and the user/report did not revert to its previous state.