### PR TITLE
feat: add suspended account page and routing with appeal option

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,8 @@ import UserProfilePage from "./pages/ProfilePage/UserProfilePage/UserProfilePage
 import OnboardingPage from "./pages/OnboardingPage/OnboardingPage";
 import AuthCallback from "./pages/AuthCallback";
 import { supabase } from "./supabase";
+import SuspendedPage from "./pages/SuspendedPage/SuspendedPage";
+
 
 function App() {
   const [currentUser, setCurrentUser] = useState(null);
@@ -244,6 +246,7 @@ useEffect(() => {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Navigate to="/login" replace />} />
+          <Route path="/suspended" element={<SuspendedPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/onboarding" element={<OnboardingPage />} />
 
@@ -264,7 +267,10 @@ useEffect(() => {
                 <Navigate to="/login" replace />
               ) : !profileReady ? (
                 <div>Loading...</div>
-              ) : currentUser.role === "admin" ||
+              ) : currentUser.role === "suspended" ? (
+                <Navigate to="/suspended" replace />
+              )
+               : currentUser.role === "admin" ||
                 currentUser.role === "superadmin" ? (
                 <Navigate to="/admin" replace />
               ) : !currentUser.privacy_acknowledged ? (

--- a/src/components/AdminRouteGuard.jsx
+++ b/src/components/AdminRouteGuard.jsx
@@ -5,6 +5,8 @@ import AppContext from "../AppContext";
 const AdminRouteGuard = ({ children }) => {
   const { currentUser } = useContext(AppContext)
 
+
+  
   if (!currentUser) {
     return <Navigate to="/login" replace />
   }

--- a/src/pages/SuspendedPage/SuspendedPage.css
+++ b/src/pages/SuspendedPage/SuspendedPage.css
@@ -1,0 +1,119 @@
+.sp-root {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fef2f2;
+  padding: 1.5rem;
+}
+
+.sp-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+  padding: 2.5rem 2rem;
+  max-width: 440px;
+  width: 100%;
+  text-align: center;
+}
+
+.sp-icon-wrap {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: #fee2e2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1.25rem;
+}
+
+.sp-icon {
+  color: #dc2626;
+}
+
+.sp-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #dc2626;
+  margin: 0 0 0.5rem;
+}
+
+.sp-sub {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin: 0 0 1.5rem;
+}
+
+.sp-message-box {
+  background: #fef9c3;
+  border: 1px solid #fde047;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: left;
+}
+
+.sp-message-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #92400e;
+  margin: 0 0 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.sp-message-text {
+  font-size: 0.875rem;
+  color: #1f2937;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.sp-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.sp-btn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.15s;
+}
+
+.sp-btn:hover { opacity: 0.88; }
+
+.sp-btn--primary {
+  background: #dc2626;
+  color: #fff;
+}
+
+.sp-btn--ghost {
+  background: transparent;
+  border: 1.5px solid #d1d5db;
+  color: #374151;
+}
+
+.sp-appeal-placeholder {
+  background: #f3f4f6;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.82rem;
+  color: #6b7280;
+  line-height: 1.6;
+}
+
+.sp-appeal-placeholder p { margin: 0; }
+
+.sp-footer {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin: 0;
+}

--- a/src/pages/SuspendedPage/SuspendedPage.jsx
+++ b/src/pages/SuspendedPage/SuspendedPage.jsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { ShieldAlert } from "lucide-react";
+import { supabase } from "../../supabase";
+import AppContext from "../../AppContext";
+import "./SuspendedPage.css";
+
+export default function SuspendedPage() {
+  const { currentUser } = useContext(AppContext);
+  const navigate = useNavigate();
+  const [suspensionMessage, setSuspensionMessage] = useState(null);
+  const [appealClicked, setAppealClicked] = useState(false);
+
+  useEffect(() => {
+    if (!currentUser?.id) return;
+    async function fetchSuspensionNotif() {
+      const { data } = await supabase
+        .from("notifications")
+        .select("content, created_at")
+        .eq("user_id", currentUser.id)
+        .eq("type", "moderation")
+        .eq("title", "Account Suspended")
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .single();
+      if (data) setSuspensionMessage(data.content);
+    }
+    fetchSuspensionNotif();
+  }, [currentUser?.id]);
+
+  const handleBackToLogin = async () => {
+    await supabase.auth.signOut();
+    navigate("/login", { replace: true });
+  };
+
+  return (
+    <div className="sp-root">
+      <div className="sp-card">
+        <div className="sp-icon-wrap">
+          <ShieldAlert size={40} className="sp-icon" />
+        </div>
+
+        <h1 className="sp-title">Account Suspended</h1>
+        <p className="sp-sub">
+          Your account has been restricted from accessing the platform.
+        </p>
+
+        {suspensionMessage && (
+          <div className="sp-message-box">
+            <p className="sp-message-label">Message from Admin:</p>
+            <p className="sp-message-text">{suspensionMessage}</p>
+          </div>
+        )}
+
+        <div className="sp-actions">
+          <button className="sp-btn sp-btn--primary" onClick={handleBackToLogin}>
+            Back to Login
+          </button>
+
+          {!appealClicked ? (
+            <button
+              className="sp-btn sp-btn--ghost"
+              onClick={() => setAppealClicked(true)}
+            >
+              Appeal Suspension
+            </button>
+          ) : (
+            <div className="sp-appeal-placeholder">
+              <p>Appeal functionality coming soon.</p>
+              <p>Please contact <strong>wellness@neu.edu.ph</strong> for now.</p>
+            </div>
+          )}
+        </div>
+
+        <p className="sp-footer">
+          NEU Wellness Tracker · New Era University
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### What does this PR do?
This PR introduces a dedicated landing page for users whose accounts have been suspended, ensuring they cannot access the main application while giving them clear next steps.

### Key Changes & Fixes
* **Suspended Route Logic:** Updated the main router layout to properly intercept users with the "suspended" role and redirect them to the new `/suspended` route.
* **Suspended Page Skeleton:** Created the UI placeholder for the Suspended Page.
* **Navigation & Appeals:** Added routing to allow the user to return to the Login page, as well as a placeholder/button for the account appeal process.

### Testing Notes
* Logged in with a suspended account -> Verified the app forces a redirect to the Suspended page.
* Verified the "Return to Login" and "Appeal" UI elements render correctly.