### PR TITLE
feat: implement admin appeal page, appeal function, and ban reason display

### DIFF
--- a/src/components/admin/AdminSidebar.jsx
+++ b/src/components/admin/AdminSidebar.jsx
@@ -1,4 +1,4 @@
-import { Flag, ShieldAlert, Users, LayoutGrid, Megaphone, LogOut } from "lucide-react";
+import { Flag, ShieldAlert, Users, LayoutGrid, Megaphone, LogOut, FileText } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { supabase } from "../../supabase";
@@ -8,19 +8,14 @@ const NAV_ITEMS = [
   { key: "userreports",  label: "Reported Users",   Icon: ShieldAlert },
   { key: "users",        label: "User Management",  Icon: Users },
   { key: "communities",  label: "Community Review", Icon: LayoutGrid },
-  { key: "broadcast",    label: "Broadcast",        Icon: Megaphone }, 
+  { key: "appeals",      label: "Appeals",          Icon: FileText },
+  { key: "broadcast",    label: "Broadcast",        Icon: Megaphone },
 ];
 
 export default function AdminSidebar({
-  tab,
-  setTab,
-  sidebarOpen,
-  closeSidebar,
-  pendingPosts,
-  pendingUsers,
-  resolved,
-  suspended,
-  pendingCommunityCount,
+  tab, setTab, sidebarOpen, closeSidebar,
+  pendingPosts, pendingUsers, resolved, suspended,
+  pendingCommunityCount, appealCount,
 }) {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
@@ -36,7 +31,8 @@ export default function AdminSidebar({
     userreports:  pendingUsers,
     users:        0,
     communities:  pendingCommunityCount,
-    broadcast:    0, 
+    appeals:      appealCount,
+    broadcast:    0,
   };
 
   async function handleSignOut() {
@@ -46,25 +42,17 @@ export default function AdminSidebar({
 
   return (
     <>
-      {/* Mobile overlay */}
       <div
         className={`admin-sidebar-overlay ${sidebarOpen ? "open" : ""}`}
         onClick={closeSidebar}
       />
-
       <aside className={`admin-sidebar ${sidebarOpen ? "open" : ""}`}>
-
-        {/* ── Navigation ───────────────────────────────────────────────────── */}
         <div className="admin-sidebar__label">Navigation</div>
-
         {NAV_ITEMS.map((item) => (
           <button
             key={item.key}
             className={`admin-sidebar__nav-btn ${tab === item.key ? "active" : ""}`}
-            onClick={() => {
-              setTab(item.key);
-              closeSidebar();
-            }}
+            onClick={() => { setTab(item.key); closeSidebar(); }}
           >
             <item.Icon size={16} />
             {item.label}
@@ -90,7 +78,6 @@ export default function AdminSidebar({
           </div>
         ))}
 
-        {/* ── Footer: email + Sign Out ─────────────────────────────────────── */}
         <div className="admin-sidebar__footer">
           <hr className="admin-sidebar__divider" />
           <div className="admin-sidebar__user-email" title={email}>
@@ -101,7 +88,6 @@ export default function AdminSidebar({
             Sign Out
           </button>
         </div>
-
       </aside>
     </>
   );

--- a/src/components/admin/AppealsTab.jsx
+++ b/src/components/admin/AppealsTab.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { Clock, CheckCircle, XCircle } from 'lucide-react';
+import { Avatar } from './UI';
+import { timeAgo } from '../../utils/timeAgo';
+
+export default function AppealsTab({ appeals, onResolve, onReject }) {
+  const [filter, setFilter] = useState('pending');
+  const filtered = appeals.filter(a => a.status === filter);
+
+  return (
+    <section>
+      <div className="admin-section-header">
+        <h2>Suspension Appeals</h2>
+        <div className="filter-bar">
+          {['pending', 'resolved', 'rejected'].map(f => (
+            <button
+              key={f}
+              className={`filter-btn${filter === f ? ' filter-btn--active' : ''}`}
+              onClick={() => setFilter(f)}
+            >
+              {f.charAt(0).toUpperCase() + f.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="admin-empty">No {filter} appeals.</div>
+      )}
+
+      <div className="report-list">
+        {filtered.map(appeal => (
+          <div key={appeal.id} className="report-card" style={{ borderLeftColor: 'var(--warn)' }}>
+            <div className="report-card__header">
+              <div className="report-card__meta">
+                <div className="report-card__badges">
+                  <span className="time-muted">
+                    <Clock size={11} style={{ display: 'inline', marginRight: 3 }} />
+                    {timeAgo(appeal.createdAt)}
+                  </span>
+                </div>
+                <div className="report-card__reason">
+                  Appeal from: <strong>{appeal.appellant.name}</strong>
+                </div>
+                <div className="report-card__desc" style={{ marginTop: 8, padding: '0.75rem', background: '#f9fafb', borderRadius: 8, fontSize: 13 }}>
+                  {appeal.details}
+                </div>
+              </div>
+              <div className="report-card__reporter">
+                <Avatar initials={appeal.appellant.avatar} size={28} />
+                <div className="report-card__reporter-info">
+                  <p style={{ fontSize: 11, color: 'var(--text-muted)' }}>Appellant</p>
+                  <p>{appeal.appellant.name}</p>
+                </div>
+              </div>
+            </div>
+
+            {appeal.status === 'pending' && (
+              <div className="report-card__actions">
+                <button
+                  className="btn btn--primary"
+                  onClick={() => onResolve(appeal.id, appeal.appellant.id)}
+                >
+                  <CheckCircle size={14} /> Lift Suspension
+                </button>
+                <button
+                  className="btn btn--danger"
+                  onClick={() => onReject(appeal.id)}
+                >
+                  <XCircle size={14} /> Reject Appeal
+                </button>
+              </div>
+            )}
+
+            {appeal.status !== 'pending' && (
+              <div className="report-card__note">
+                <strong>Status: </strong>
+                <span style={{ color: appeal.status === 'resolved' ? 'var(--primary)' : 'var(--danger)' }}>
+                  {appeal.status === 'resolved' ? 'Suspension lifted' : 'Appeal rejected'}
+                </span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useAdminDashboard.js
+++ b/src/hooks/useAdminDashboard.js
@@ -98,7 +98,6 @@ export function useAdminDashboard() {
     showToast('Community approved!');
   };
 
-  // PR D — Community rejection notification
   const rejectCommunity = async (id, reason) => {
     const { error } = await supabase
       .from('communities')
@@ -119,7 +118,6 @@ export function useAdminDashboard() {
           : `Your community "${community.name}" was rejected by an administrator.`,
       });
     }
-
     showToast('Community rejected.', 'danger');
   };
 
@@ -195,6 +193,62 @@ export function useAdminDashboard() {
     fetchUserReports();
   }, []);
 
+  // ---------------------------------------------------------------------------
+  // Appeals
+  // ---------------------------------------------------------------------------
+  const [appeals, setAppeals] = useState([]);
+
+  useEffect(() => {
+    async function fetchAppeals() {
+      const { data, error } = await supabase
+        .from('reports')
+        .select(`
+          id, details, created_at, status, reporter_id,
+          appellant:profiles!reports_reporter_id_fkey (
+            id, display_name
+          )
+        `)
+        .eq('type', 'appeal')
+        .order('created_at', { ascending: false });
+
+      if (error) { console.error('fetch appeals error:', error); return; }
+
+      const normalized = data.map(r => ({
+        id: r.id,
+        details: r.details,
+        status: r.status ?? 'pending',
+        createdAt: r.created_at,
+        appellant: {
+          id: r.reporter_id,
+          name: r.appellant?.display_name ?? 'Unknown',
+          avatar: (r.appellant?.display_name?.[0] ?? 'U').toUpperCase(),
+        },
+      }));
+      setAppeals(normalized);
+    }
+    fetchAppeals();
+  }, []);
+
+  const resolveAppeal = async (appealId, userId) => {
+    await supabase.from('profiles').update({ role: 'student' }).eq('id', userId);
+    await supabase.from('reports').update({ status: 'resolved' }).eq('id', appealId);
+    await supabase.from('notifications').insert({
+      user_id: userId,
+      type: 'moderation',
+      title: 'Appeal Approved',
+      content: 'Your suspension appeal has been approved. Your account has been restored.',
+    });
+    setAppeals(prev => prev.map(a => a.id === appealId ? { ...a, status: 'resolved' } : a));
+    setUsers(prev => prev.map(u => u.id === userId ? { ...u, status: 'active', role: 'student' } : u));
+    showToast('Suspension lifted. User restored.');
+  };
+
+  const rejectAppeal = async (appealId) => {
+    await supabase.from('reports').update({ status: 'rejected' }).eq('id', appealId);
+    setAppeals(prev => prev.map(a => a.id === appealId ? { ...a, status: 'rejected' } : a));
+    showToast('Appeal rejected.', 'danger');
+  };
+
   const resolvePost = async (id, res) => {
     const report = reports.find(r => r.id === id);
 
@@ -221,40 +275,27 @@ export function useAdminDashboard() {
 
   const toggleUser = async (uid, status) => {
     const newRole = status === 'suspended' ? 'suspended' : 'student';
-
-    const { error } = await supabase
-      .from('profiles')
-      .update({ role: newRole })
-      .eq('id', uid);
-
+    const { error } = await supabase.from('profiles').update({ role: newRole }).eq('id', uid);
     if (error) { console.error('toggle user error:', error); return; }
-
-    setUsers(prev =>
-      prev.map(u => u.id === uid ? { ...u, status } : u)
-    );
+    setUsers(prev => prev.map(u => u.id === uid ? { ...u, status } : u));
     showToast(
       status === 'suspended' ? 'User suspended.' : 'User reactivated.',
       status === 'suspended' ? 'danger' : 'success'
     );
   };
 
-  // PR C — Suspend user notification
   const resolveUserReport = async (id, resolution) => {
     if (resolution === "suspended") {
       const report = userReports.find(r => r.id === id);
       const uid = report?.reportedUser?.id;
 
       if (uid) {
-        const { error } = await supabase
-          .from("profiles")
-          .update({ role: "suspended" })
-          .eq("id", uid);
+        const { error } = await supabase.from("profiles").update({ role: "suspended" }).eq("id", uid);
         if (error) console.error("suspend profile error:", error);
         else {
           setUsers(prev =>
             prev.map(u => u.id === uid ? { ...u, status: "suspended", role: "suspended" } : u)
           );
-
           await supabase.from("notifications").insert({
             user_id: uid,
             type: "moderation",
@@ -267,18 +308,11 @@ export function useAdminDashboard() {
       }
     }
 
-    const { error } = await supabase
-      .from("reports")
-      .update({ status: "resolved", resolution })
-      .eq("id", id);
-
+    const { error } = await supabase.from("reports").update({ status: "resolved", resolution }).eq("id", id);
     if (error) console.error("resolve report error:", error);
 
     setUserReports(prev =>
-      prev.map(r => r.id === id
-        ? { ...r, status: "resolved", resolution, adminNote: note }
-        : r
-      )
+      prev.map(r => r.id === id ? { ...r, status: "resolved", resolution, adminNote: note } : r)
     );
     setUserModal(null);
     setSelUserReport(null);
@@ -290,33 +324,18 @@ export function useAdminDashboard() {
   };
 
   const broadcastNotification = async ({ title, message, targetType, selectedUserIds }) => {
-    if (!message.trim()) {
-      showToast('Message cannot be empty.', 'danger');
-      return false;
-    }
+    if (!message.trim()) { showToast('Message cannot be empty.', 'danger'); return false; }
 
     let recipientIds = [];
-
     if (targetType === 'all') {
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('id')
-        .neq('role', 'suspended');
-
-      if (error) {
-        console.error('broadcast fetch users error:', error);
-        showToast('Failed to fetch users.', 'danger');
-        return false;
-      }
+      const { data, error } = await supabase.from('profiles').select('id').neq('role', 'suspended');
+      if (error) { showToast('Failed to fetch users.', 'danger'); return false; }
       recipientIds = data.map(u => u.id);
     } else {
       recipientIds = selectedUserIds ?? [];
     }
 
-    if (recipientIds.length === 0) {
-      showToast('No recipients selected.', 'danger');
-      return false;
-    }
+    if (recipientIds.length === 0) { showToast('No recipients selected.', 'danger'); return false; }
 
     const rows = recipientIds.map(uid => ({
       user_id: uid,
@@ -327,12 +346,7 @@ export function useAdminDashboard() {
     }));
 
     const { error } = await supabase.from('notifications').insert(rows);
-
-    if (error) {
-      console.error('broadcast insert error:', error);
-      showToast('Broadcast failed. Check console.', 'danger');
-      return false;
-    }
+    if (error) { showToast('Broadcast failed. Check console.', 'danger'); return false; }
 
     showToast(`Announcement sent to ${recipientIds.length} user(s)!`);
     return true;
@@ -340,19 +354,18 @@ export function useAdminDashboard() {
 
   const closeSidebar = () => setSidebarOpen(false);
 
-  const pendingPosts = reports.filter(r => r.status === 'pending').length;
-  const resolved     = reports.filter(r => r.status === 'resolved').length;
-  const suspended    = users.filter(u => u.status === 'suspended').length;
-  const pendingUsers = userReports.filter(r => r.status === 'pending').length;
+  const pendingPosts  = reports.filter(r => r.status === 'pending').length;
+  const resolved      = reports.filter(r => r.status === 'resolved').length;
+  const suspended     = users.filter(u => u.status === 'suspended').length;
+  const pendingUsers  = userReports.filter(r => r.status === 'pending').length;
+  const appealCount   = appeals.filter(a => a.status === 'pending').length;
 
   return {
     tab, setTab,
     sidebarOpen, setSidebarOpen, closeSidebar,
     filter, setFilter,
     urFilter, setUrFilter,
-    reports,
-    userReports,
-    users,
+    reports, userReports, users,
     selReport, setSelReport,
     selUserReport, setSelUserReport,
     postModal, setPostModal,
@@ -360,17 +373,12 @@ export function useAdminDashboard() {
     note, setNote,
     toast,
     search, setSearch,
-    pendingPosts,
-    pendingUsers,
-    resolved,
-    suspended,
-    resolvePost,
-    resolveUserReport,
-    toggleUser,
+    pendingPosts, pendingUsers, resolved, suspended,
+    resolvePost, resolveUserReport, toggleUser,
     pendingCommunities,
-    approveCommunity,
-    rejectCommunity,
+    approveCommunity, rejectCommunity,
     pendingCommunityCount: pendingCommunities.length,
     broadcastNotification,
+    appeals, resolveAppeal, rejectAppeal, appealCount,
   };
 }

--- a/src/pages/AdminPage/AdminDashboard.jsx
+++ b/src/pages/AdminPage/AdminDashboard.jsx
@@ -10,6 +10,7 @@ import PostReportModal from "../../components/admin/PostReportModal";
 import UserReportModal from "../../components/admin/UserReportModal";
 import CommunityReviewTab from "../../components/admin/CommunityReviewTab/CommunityReviewTab";
 import BroadcastTab from "../../components/admin/BroadcastTab/BroadcastTab";
+import AppealsTab from "../../components/admin/AppealsTab";
 
 export default function AdminDashboard() {
   const {
@@ -28,10 +29,10 @@ export default function AdminDashboard() {
     pendingPosts, pendingUsers, resolved, suspended,
     resolvePost, resolveUserReport, toggleUser,
     pendingCommunities,
-    approveCommunity,
-    rejectCommunity,
+    approveCommunity, rejectCommunity,
     pendingCommunityCount,
-    broadcastNotification,  // ← NEW
+    broadcastNotification,
+    appeals, resolveAppeal, rejectAppeal, appealCount,
   } = useAdminDashboard();
 
   return (
@@ -55,18 +56,17 @@ export default function AdminDashboard() {
           resolved={resolved}
           suspended={suspended}
           pendingCommunityCount={pendingCommunityCount}
-          hasBroadcast
+          appealCount={appealCount}
         />
 
         <main className="admin-main">
 
-          {/* Stats row */}
           <div className="admin-stats-grid">
-            <StatCard label="Pending Post Reports" value={pendingPosts}          sub="Awaiting review"        accent="var(--warn)" />
-            <StatCard label="Pending User Reports" value={pendingUsers}          sub="Awaiting review"        accent="#E65100" />
-            <StatCard label="Pending Communities"  value={pendingCommunityCount} sub="Awaiting approval"      accent="var(--primary)" />
-            <StatCard label="Resolved Reports"     value={resolved}              sub="All time"               accent="var(--primary)" />
-            <StatCard label="Suspended Users"      value={suspended}             sub="Currently restricted"   accent="var(--danger)" />
+            <StatCard label="Pending Post Reports" value={pendingPosts}          sub="Awaiting review"      accent="var(--warn)" />
+            <StatCard label="Pending User Reports" value={pendingUsers}          sub="Awaiting review"      accent="#E65100" />
+            <StatCard label="Pending Communities"  value={pendingCommunityCount} sub="Awaiting approval"    accent="var(--primary)" />
+            <StatCard label="Resolved Reports"     value={resolved}              sub="All time"             accent="var(--primary)" />
+            <StatCard label="Suspended Users"      value={suspended}             sub="Currently restricted" accent="var(--danger)" />
           </div>
 
           {tab === "reports" && (
@@ -106,7 +106,14 @@ export default function AdminDashboard() {
             />
           )}
 
-          {/* ── NEW: Broadcast tab ────────────────────────────────────── */}
+          {tab === "appeals" && (
+            <AppealsTab
+              appeals={appeals}
+              onResolve={resolveAppeal}
+              onReject={rejectAppeal}
+            />
+          )}
+
           {tab === "broadcast" && (
             <BroadcastTab
               users={users}
@@ -117,7 +124,6 @@ export default function AdminDashboard() {
         </main>
       </div>
 
-      {/* Modals */}
       <PostReportModal
         report={selReport}
         mode={postModal}
@@ -136,7 +142,6 @@ export default function AdminDashboard() {
         onResolve={resolveUserReport}
       />
 
-      {/* Toast */}
       {toast && (
         <div className={`toast toast--${toast.type}`}>{toast.msg}</div>
       )}

--- a/src/pages/SuspendedPage/SuspendedPage.css
+++ b/src/pages/SuspendedPage/SuspendedPage.css
@@ -28,9 +28,7 @@
   margin: 0 auto 1.25rem;
 }
 
-.sp-icon {
-  color: #dc2626;
-}
+.sp-icon { color: #dc2626; }
 
 .sp-title {
   font-size: 1.5rem;
@@ -86,14 +84,16 @@
   cursor: pointer;
   border: none;
   transition: opacity 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
 }
 
-.sp-btn:hover { opacity: 0.88; }
+.sp-btn:hover:not(:disabled) { opacity: 0.88; }
+.sp-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
-.sp-btn--primary {
-  background: #dc2626;
-  color: #fff;
-}
+.sp-btn--primary { background: #dc2626; color: #fff; }
 
 .sp-btn--ghost {
   background: transparent;
@@ -101,16 +101,84 @@
   color: #374151;
 }
 
-.sp-appeal-placeholder {
-  background: #f3f4f6;
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
-  font-size: 0.82rem;
-  color: #6b7280;
-  line-height: 1.6;
+.sp-btn--submit { background: #1d4ed8; color: #fff; }
+
+.sp-btn--sm { padding: 0.6rem 1rem; font-size: 0.85rem; }
+
+/* ── Appeal form ── */
+.sp-appeal-form {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: left;
 }
 
-.sp-appeal-placeholder p { margin: 0; }
+.sp-appeal-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 0.25rem;
+}
+
+.sp-appeal-hint {
+  font-size: 0.78rem;
+  color: #6b7280;
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.sp-appeal-textarea {
+  width: 100%;
+  border: 1.5px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.85rem;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: inherit;
+  color: #1f2937;
+  margin-bottom: 0.5rem;
+}
+
+.sp-appeal-textarea:focus {
+  outline: none;
+  border-color: #1d4ed8;
+}
+
+.sp-appeal-error {
+  font-size: 0.78rem;
+  color: #dc2626;
+  margin: 0 0 0.5rem;
+}
+
+.sp-appeal-btns {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* ── Appeal success ── */
+.sp-appeal-success {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 10px;
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: #166534;
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.sp-appeal-success p { margin: 0; }
+
+.sp-appeal-success-icon {
+  color: #16a34a;
+  margin-bottom: 4px;
+}
 
 .sp-footer {
   font-size: 0.75rem;

--- a/src/pages/SuspendedPage/SuspendedPage.jsx
+++ b/src/pages/SuspendedPage/SuspendedPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { ShieldAlert } from "lucide-react";
+import { ShieldAlert, Send, CheckCircle } from "lucide-react";
 import { supabase } from "../../supabase";
 import AppContext from "../../AppContext";
 import "./SuspendedPage.css";
@@ -9,7 +9,10 @@ export default function SuspendedPage() {
   const { currentUser } = useContext(AppContext);
   const navigate = useNavigate();
   const [suspensionMessage, setSuspensionMessage] = useState(null);
-  const [appealClicked, setAppealClicked] = useState(false);
+
+  const [appealStep, setAppealStep] = useState("idle"); // idle | form | submitting | done
+  const [appealText, setAppealText] = useState("");
+  const [appealError, setAppealError] = useState("");
 
   useEffect(() => {
     if (!currentUser?.id) return;
@@ -32,6 +35,32 @@ export default function SuspendedPage() {
     await supabase.auth.signOut();
     navigate("/login", { replace: true });
   };
+
+  const handleSubmitAppeal = async () => {
+  if (!appealText.trim()) {
+    setAppealError("Please explain your appeal before submitting.");
+    return;
+  }
+  setAppealError("");
+  setAppealStep("submitting");
+
+  const { error } = await supabase.from("reports").insert({
+    reporter_id: currentUser.id,
+    type: "appeal",
+    reason: "suspension_appeal",
+    details: appealText.trim(),
+    status: "pending",
+  });
+
+  if (error) {
+    console.error("appeal error:", error);
+    setAppealError("Submission failed. Please try again.");
+    setAppealStep("form");
+    return;
+  }
+
+  setAppealStep("done");
+};
 
   return (
     <div className="sp-root">
@@ -57,17 +86,58 @@ export default function SuspendedPage() {
             Back to Login
           </button>
 
-          {!appealClicked ? (
+          {/* ── Appeal states ── */}
+          {appealStep === "idle" && (
             <button
               className="sp-btn sp-btn--ghost"
-              onClick={() => setAppealClicked(true)}
+              onClick={() => setAppealStep("form")}
             >
               Appeal Suspension
             </button>
-          ) : (
-            <div className="sp-appeal-placeholder">
-              <p>Appeal functionality coming soon.</p>
-              <p>Please contact <strong>wellness@neu.edu.ph</strong> for now.</p>
+          )}
+
+          {(appealStep === "form" || appealStep === "submitting") && (
+            <div className="sp-appeal-form">
+              <p className="sp-appeal-title">Submit an Appeal</p>
+              <p className="sp-appeal-hint">
+                Explain why you believe this suspension should be reviewed.
+              </p>
+              <textarea
+                className="sp-appeal-textarea"
+                rows={4}
+                placeholder="Write your appeal here..."
+                value={appealText}
+                onChange={(e) => setAppealText(e.target.value)}
+                disabled={appealStep === "submitting"}
+              />
+              {appealError && (
+                <p className="sp-appeal-error">{appealError}</p>
+              )}
+              <div className="sp-appeal-btns">
+                <button
+                  className="sp-btn sp-btn--ghost sp-btn--sm"
+                  onClick={() => { setAppealStep("idle"); setAppealText(""); setAppealError(""); }}
+                  disabled={appealStep === "submitting"}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="sp-btn sp-btn--submit sp-btn--sm"
+                  onClick={handleSubmitAppeal}
+                  disabled={appealStep === "submitting"}
+                >
+                  <Send size={14} />
+                  {appealStep === "submitting" ? "Submitting..." : "Submit Appeal"}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {appealStep === "done" && (
+            <div className="sp-appeal-success">
+              <CheckCircle size={20} className="sp-appeal-success-icon" />
+              <p>Your appeal has been submitted.</p>
+              <p>An administrator will review it shortly.</p>
             </div>
           )}
         </div>


### PR DESCRIPTION
### What does this PR do?
This PR introduces the full account appeal workflow. Suspended users can now see exactly why they were banned and submit an appeal, and admins have a dedicated page to review and handle these appeals.

### Key Changes & Fixes
* **Ban Reason Display:** Updated the Suspended page to fetch and display the specific reason for the user's account suspension.
* **Appeal Functionality:** Implemented the logic allowing suspended users to submit an appeal.
* **Admin Dashboard Appeal Page:** Built out the dedicated view in the Admin Dashboard for admins to review, accept, or reject incoming appeals.

### Testing Notes
* Logged in as a suspended user -> Verified the ban reason is visible.
* Submitted an appeal -> Verified the appeal registers successfully.
* Logged in as an admin -> Navigated to the new appeals page and verified the submitted appeal populates correctly.