### PR TITLE
Feat: Limit notification dropdown to 8 recent items

### DIFF
--- a/src/components/notifications/NotificationsPanel.jsx
+++ b/src/components/notifications/NotificationsPanel.jsx
@@ -31,7 +31,7 @@ export default function NotificationsPanel() {
     
 
       <div className="neu-notif-list">
-        {myNotifs.map((notif) => (
+        {myNotifs.slice(0, 8).map((notif) => (
           <NotificationItem
             key={notif.id}
             notif={notif}


### PR DESCRIPTION
## Description
This PR limits the number of notifications displayed in the Topbar bell dropdown to a maximum of 8. 

## Changes Made
* **`src/components/notifications/NotificationsPanel.jsx`**: 
  * Appended `.slice(0, 8)` to the `myNotifs` array map function. This caps the rendered `NotificationItem` components in the dropdown menu to the 8 most recent entries, preventing UI overflow. The full history remains accessible via the "View all notifications" link which routes to the dedicated `NotificationsPage`.