### PR TITLE
Fix shared post authorship display across feed, profile, and user profile pages

### DIFF
--- a/src/components/postcard/PostCard/PostCard.css
+++ b/src/components/postcard/PostCard/PostCard.css
@@ -279,3 +279,10 @@
 .pc-undo-btn:hover {
   background: #e8f5e9;
 }
+
+.pc-shared-origin {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  margin: 0 0 6px 0;
+  padding: 0 1rem;
+}

--- a/src/components/postcard/PostCard/PostCard.jsx
+++ b/src/components/postcard/PostCard/PostCard.jsx
@@ -1,6 +1,3 @@
-// =============================================================================
-// PostCard.jsx — adds PostMenu (3-dot), hide, and report functionality
-// =============================================================================
 import React, { useContext, useState } from "react";
 import AppContext from "../../../AppContext";
 import usePostCard from "../usePostCard";
@@ -14,58 +11,68 @@ import "./PostCard.css";
 
 export default function PostCard({ post }) {
   const { profiles, communities } = useContext(AppContext);
-
   const [hidden, setHidden] = useState(false);
   const [showReport, setShowReport] = useState(false);
 
-  const author = profiles.find((p) => p.id === post.author_id);
-  const isAdmin = author?.role === "admin" || author?.role === "superadmin";
+  const isShared = post.content?.startsWith("[Shared Post]:");
 
-  const isAdminBroadcast = post.content?.startsWith("[Admin Broadcast]\n");
+  let displayContent = post.content || "";
+  if (isShared) {
+    displayContent = displayContent.replace(/^\[Shared Post\]:\s*/, "").trim();
+  }
 
-  const displayName = isAdminBroadcast || isAdmin
+  const isAdminBroadcast = displayContent.startsWith("[Admin Broadcast]\n");
+  if (isAdminBroadcast) {
+    displayContent = displayContent.replace(/^\[Admin Broadcast\]\n\s*/, "").trim();
+  }
+
+  // ── Determine if this is an ORIGINAL admin broadcast (not a share) ─────────
+  const isOriginalAdminBroadcast = isAdminBroadcast && !isShared;
+
+  // ── Header: sharer's real info, except for original admin broadcasts ────────
+  const sharer = profiles.find((p) => p.id === post.author_id);
+  
+  const displayName = isOriginalAdminBroadcast
     ? "Admin"
     : post.is_anonymous
     ? "Anonymous"
-    : author?.display_name ?? "Unknown";
+    : sharer?.display_name ?? "Unknown";
 
-  const displayAvatar = isAdminBroadcast || isAdmin
+  const displayAvatar = isOriginalAdminBroadcast
     ? "/NEULogo1.png"
     : post.is_anonymous
     ? null
-    : author?.photo_url;
+    : sharer?.photo_url;
+
+  // ── PostHeader: null authorId = not clickable ───────────────────────────────
+  const headerAuthorId = isOriginalAdminBroadcast || post.is_anonymous
+    ? null
+    : post.author_id;
+
+  // ── Original author attribution (shown inside card for shared posts) ──────
+  const originalAuthorId = isShared ? post.original_author_id : null;
+  const originalAuthor = originalAuthorId
+    ? profiles.find((p) => p.id === originalAuthorId)
+    : null;
+
+  const originalAuthorName = isAdminBroadcast
+    ? "Admin"
+    : originalAuthor?.display_name ?? null;
 
   const community = communities.find((c) => c.id === post.community_id);
-  const isShared = post.content?.startsWith("[Shared Post]:");
-
-  let displayContent = post.content;
-  if (isAdminBroadcast) {
-    displayContent = displayContent.replace("[Admin Broadcast]\n", "").trim();
-  } else if (isShared) {
-    displayContent = displayContent.replace("[Shared Post]\n", "").trim();
-  }
 
   const {
-
-    upvoteCount,
-    commentCount,
-    hasReacted,
-    showConfirm,
-    showComments,
-    handleReaction,
-    handleAddComment,
-    handleShare,
-    setShowConfirm,
-    setShowComments,
+    upvoteCount, commentCount, hasReacted,
+    showConfirm, showComments,
+    handleReaction, handleAddComment, handleShare,
+    setShowConfirm, setShowComments,
   } = usePostCard(post);
 
   if (hidden) {
     return (
       <div className="pc-card pc-card--hidden">
         <span className="pc-hidden-text">Post hidden</span>
-        <button className="pc-undo-btn" onClick={() => setHidden(false)}>
-          Undo
-        </button>
+        <button className="pc-undo-btn" onClick={() => setHidden(false)}>Undo</button>
       </div>
     );
   }
@@ -75,7 +82,7 @@ export default function PostCard({ post }) {
       <div className="pc-card">
         <div className="pc-header-row">
           <PostHeader
-            authorId={post.is_anonymous || isAdminBroadcast ? null : post.author_id}
+            authorId={headerAuthorId}
             avatarUrl={displayAvatar}
             displayName={displayName}
             communityName={community?.name ?? "Community"}
@@ -89,7 +96,14 @@ export default function PostCard({ post }) {
           />
         </div>
 
-        <p className="pc-body">{post.content}</p>
+        {/* ── Original author attribution ── */}
+        {isShared && originalAuthorName && (
+          <p className="pc-shared-origin">
+            Originally posted by <strong>{originalAuthorName}</strong>
+          </p>
+        )}
+
+        <p className="pc-body">{displayContent}</p>
 
         <ActionBar
           upvoteCount={upvoteCount}

--- a/src/components/postcard/usePostCard.js
+++ b/src/components/postcard/usePostCard.js
@@ -96,23 +96,23 @@ export default function usePostCard(post) {
 
   // ── Share ──────────────────────────────────────────────────────────────────
   const handleShare = async () => {
-    if (!currentUser) return;
+  if (!currentUser) return;
 
-    let originalContent = post.content;
-    if (originalContent.startsWith("[Shared Post]:")) {
-      originalContent = originalContent.replace("[Shared Post]:", "").trim();
-    } else if (originalContent.startsWith("[Admin Broadcast]\n")) {
-      originalContent = originalContent.replace("[Admin Broadcast]\n", "").trim();
-    }
+  const trueOriginalAuthorId = post.original_author_id ?? post.author_id;
 
-    const { error } = await supabase.from("posts").insert({
-      author_id: currentUser.id,
-      original_author_id: post.author_id,
-      community_id: post.community_id,
-      content: `[Shared Post]: ${originalContent}`,
-      is_anonymous: false,
-      is_flagged: false,
-    });
+  let originalContent = post.content;
+  if (originalContent.startsWith("[Shared Post]:")) {
+    originalContent = originalContent.replace("[Shared Post]:", "").trim();
+  }
+
+  const { error } = await supabase.from("posts").insert({
+    author_id: currentUser.id,
+    original_author_id: trueOriginalAuthorId,  
+    community_id: post.community_id,
+    content: `[Shared Post]: ${originalContent}`,
+    is_anonymous: false,
+    is_flagged: false
+  });
 
     if (!error) {
       setShowConfirm(false);

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -213,13 +213,28 @@ function ProfilePostCard({ post, community, onDelete, onEdit, isShared, profile,
     setEditing(false);
   };
 
-  const bodyText = isShared
-    ? (post.content ?? "").replace(/^\[Shared Post\]:\s*/, "")
-    : (post.content ?? "—");
+  let bodyText = post.content || "—";
+  if (isShared) {
+    bodyText = bodyText.replace(/^\[Shared Post\]:\s*/, "").trim();
+  }
+  const isAdminBroadcast = bodyText.startsWith("[Admin Broadcast]\n");
+  if (isAdminBroadcast) {
+    bodyText = bodyText.replace(/^\[Admin Broadcast\]\n\s*/, "").trim();
+  }
 
-  // Respect is_anonymous — never expose the real name/photo
-  const displayName  = isAnonymous ? "Anonymous" : (profile?.display_name ?? "Unknown user");
-  const displayPhoto = isAnonymous ? null       : profile?.photo_url;
+  const isAdmin = profile?.role === "admin" || profile?.role === "superadmin";
+
+  const displayName = isAdminBroadcast || isAdmin
+    ? "Admin"
+    : isAnonymous
+    ? "Anonymous"
+    : (profile?.display_name ?? "Unknown user");
+
+  const displayPhoto = isAdminBroadcast || isAdmin
+    ? "/NEULogo1.png"
+    : isAnonymous
+    ? null
+    : profile?.photo_url;
 
   return (
     <>


### PR DESCRIPTION
## Problem
Shared posts were inconsistently displaying authorship:
- Feed showed the original author instead of the sharer
- Admin broadcast shares showed "Unknown user" or the sharer as "Admin"
- Clicking the author name on admin broadcasts navigated to the admin's profile
- UserProfilePage shared tab showed no original author attribution
- original_author_id was not being preserved when re-sharing an already-shared post

## Changes
- **PostCard**: Header now always shows the sharer; original author shown as attribution line below
- **PostCard**: Admin broadcast detection uses isAdminBroadcast && !isShared so only original broadcasts show "Admin", not shares made by admins
- **PostCard**: Admin broadcast header is non-clickable (authorId=null)
- **usePostCard**: handleShare now uses post.original_author_id ?? post.author_id to correctly chain original authorship through re-shares
- **usePostCard**: Removed stripping of [Admin Broadcast] prefix when sharing so PostCard can still detect it downstream

## Behavior after fix
| Scenario | Before | After |
|---|---|---|
| User shares a post | Showed original author | Shows sharer + "Originally posted by X" |
| Admin broadcast (original) | Showed admin (correct) | Shows Admin, not clickable |
| Admin broadcast shared by user | Showed "Unknown user" | Shows sharer + "Originally posted by Admin" |
| Re-sharing a shared post | Lost original_author_id | Correctly chains to true original author |