### PR TITLE
feat: localStorage persistence for WaterTracker, WalkTimer, and MeditationPanel

### DIFF
--- a/src/pages/HabitsPage/habits/MorningMeditation.jsx
+++ b/src/pages/HabitsPage/habits/MorningMeditation.jsx
@@ -1,24 +1,42 @@
 import React, { useState, useEffect, useRef } from "react";
+
 const BREATH_PHASES = [
   { label: "Inhale", duration: 4, scale: 1.35, color: "#A5D6A7" },
-  { label: "Hold", duration: 4, scale: 1.35, color: "#FFF176" },
-  { label: "Exhale", duration: 6, scale: 1.0, color: "#90CAF9" },
-  { label: "Rest", duration: 2, scale: 1.0, color: "#CE93D8" },
+  { label: "Hold",   duration: 4, scale: 1.35, color: "#FFF176" },
+  { label: "Exhale", duration: 6, scale: 1.0,  color: "#90CAF9" },
+  { label: "Rest",   duration: 2, scale: 1.0,  color: "#CE93D8" },
 ];
 
 const TOTAL_CYCLE = BREATH_PHASES.reduce((s, p) => s + p.duration, 0);
+const REQUIRED_SESSIONS = 3;
 
-export function MeditationPanel({
-  habitId,
-  logged,
-  onToggleLog,
-  completionCount,
-}) {
+export function MeditationPanel({ habitId, logged, onToggleLog, completionCount }) {
+  const todayStr = new Date().toISOString().split("T")[0];
+  const storageKey = `meditation_${habitId}_${todayStr}`;
+
   const [showPanel, setShowPanel] = useState(false);
   const [running, setRunning] = useState(false);
-  const [elapsed, setElapsed] = useState(0); // seconds in current cycle
-  const [sessions, setSessions] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+
+  // Initialize sessions from localStorage
+  const [sessions, setSessions] = useState(() => {
+    if (logged) return REQUIRED_SESSIONS;
+    const saved = localStorage.getItem(storageKey);
+    return saved ? parseInt(saved, 10) : 0;
+  });
+
   const intervalRef = useRef(null);
+
+  // Sync if logged prop changes externally
+  useEffect(() => {
+    if (logged && sessions < REQUIRED_SESSIONS) {
+      setSessions(REQUIRED_SESSIONS);
+      localStorage.setItem(storageKey, REQUIRED_SESSIONS);
+    } else if (!logged && sessions >= REQUIRED_SESSIONS) {
+      setSessions(0);
+      localStorage.setItem(storageKey, 0);
+    }
+  }, [logged, habitId, storageKey, sessions]);
 
   // Determine current phase
   let acc = 0;
@@ -42,7 +60,9 @@ export function MeditationPanel({
           if (next >= TOTAL_CYCLE) {
             setSessions((s) => {
               const ns = s + 1;
-              if (ns >= 3 && !logged) onToggleLog(habitId);
+              // Persist new session count
+              localStorage.setItem(storageKey, ns);
+              if (ns >= REQUIRED_SESSIONS && !logged) onToggleLog(habitId);
               return ns;
             });
             return 0;
@@ -73,8 +93,7 @@ export function MeditationPanel({
           <div>
             <p className="hp-name">Morning Meditation (10 min)</p>
             <p className="hp-streak">
-              {completionCount} total completion
-              {completionCount !== 1 ? "s" : ""}
+              {completionCount} total completion{completionCount !== 1 ? "s" : ""}
             </p>
           </div>
         </div>
@@ -92,8 +111,7 @@ export function MeditationPanel({
       {showPanel && (
         <div className="habit-panel meditation-panel">
           <p className="panel-title">
-            Breathing Exercise · {sessions} cycle{sessions !== 1 ? "s" : ""}{" "}
-            completed
+            Breathing Exercise · {sessions} / {REQUIRED_SESSIONS} cycle{sessions !== 1 ? "s" : ""} completed
           </p>
 
           {/* Animated breathing orb */}
@@ -117,9 +135,7 @@ export function MeditationPanel({
               style={{
                 background: `radial-gradient(circle at 35% 35%, white, ${currentPhase.color})`,
                 transform: `scale(${running ? currentPhase.scale : 1})`,
-                boxShadow: running
-                  ? `0 0 40px ${currentPhase.color}99`
-                  : "none",
+                boxShadow: running ? `0 0 40px ${currentPhase.color}99` : "none",
               }}
             >
               <span className="breath-phase-label">
@@ -130,21 +146,14 @@ export function MeditationPanel({
               )}
             </div>
 
-            {/* Circular progress arc */}
             {running && (
               <svg className="breath-arc" viewBox="0 0 200 200">
                 <circle
-                  cx="100"
-                  cy="100"
-                  r="90"
-                  fill="none"
-                  stroke="#E0E0E0"
-                  strokeWidth="3"
+                  cx="100" cy="100" r="90"
+                  fill="none" stroke="#E0E0E0" strokeWidth="3"
                 />
                 <circle
-                  cx="100"
-                  cy="100"
-                  r="90"
+                  cx="100" cy="100" r="90"
                   fill="none"
                   stroke={currentPhase.color}
                   strokeWidth="3"
@@ -152,9 +161,7 @@ export function MeditationPanel({
                   strokeDashoffset={`${2 * Math.PI * 90 * (1 - breathProgress)}`}
                   strokeLinecap="round"
                   transform="rotate(-90 100 100)"
-                  style={{
-                    transition: "stroke-dashoffset 1s linear, stroke 0.5s ease",
-                  }}
+                  style={{ transition: "stroke-dashoffset 1s linear, stroke 0.5s ease" }}
                 />
               </svg>
             )}
@@ -165,7 +172,11 @@ export function MeditationPanel({
             {BREATH_PHASES.map((p) => (
               <div
                 key={p.label}
-                className={`breath-phase-chip${currentPhase.label === p.label && running ? " breath-phase-chip--active" : ""}`}
+                className={`breath-phase-chip${
+                  currentPhase.label === p.label && running
+                    ? " breath-phase-chip--active"
+                    : ""
+                }`}
                 style={
                   currentPhase.label === p.label && running
                     ? { background: p.color, borderColor: p.color }
@@ -192,7 +203,7 @@ export function MeditationPanel({
           </div>
 
           <p className="med-hint">
-            Complete 3 breathing cycles to mark as done
+            Complete {REQUIRED_SESSIONS} breathing cycles to mark as done
           </p>
         </div>
       )}

--- a/src/pages/HabitsPage/habits/WalkTimer.jsx
+++ b/src/pages/HabitsPage/habits/WalkTimer.jsx
@@ -1,29 +1,69 @@
-import React, {
-  useState,
-  useEffect,useRef
-} from "react";
-// ── Walk Timer ────────────────────────────────────────────────────────────────
+import React, { useState, useEffect, useRef } from "react";
+
 const WALK_DURATION = 30 * 60; // 30 minutes in seconds
 
 export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
+  const todayStr = new Date().toISOString().split("T")[0];
+  const storageKey = `walk_timer_${habitId}_${todayStr}`;
+
   const [showPanel, setShowPanel] = useState(false);
-  const [timeLeft,  setTimeLeft]  = useState(WALK_DURATION);
-  const [running,   setRunning]   = useState(false);
-  const [finished,  setFinished]  = useState(false);
+  const [running, setRunning] = useState(false);
+
+  // Initialize timeLeft and finished from localStorage
+  const [timeLeft, setTimeLeft] = useState(() => {
+    if (logged) return 0;
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      return parsed.timeLeft ?? WALK_DURATION;
+    }
+    return WALK_DURATION;
+  });
+
+  const [finished, setFinished] = useState(() => {
+    if (logged) return true;
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      return parsed.finished ?? false;
+    }
+    return false;
+  });
+
   const intervalRef = useRef(null);
+
+  // Sync if logged prop changes externally
+  useEffect(() => {
+    if (logged && !finished) {
+      setFinished(true);
+      setTimeLeft(0);
+      const state = { timeLeft: 0, finished: true };
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    } else if (!logged && finished) {
+      setFinished(false);
+      setTimeLeft(WALK_DURATION);
+      const state = { timeLeft: WALK_DURATION, finished: false };
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    }
+  }, [logged, habitId, storageKey, finished]);
 
   useEffect(() => {
     if (running && timeLeft > 0) {
       intervalRef.current = setInterval(() => {
         setTimeLeft((t) => {
-          if (t <= 1) {
+          const next = t - 1;
+          if (next <= 0) {
             clearInterval(intervalRef.current);
             setRunning(false);
             setFinished(true);
+            const state = { timeLeft: 0, finished: true };
+            localStorage.setItem(storageKey, JSON.stringify(state));
             if (!logged) onToggleLog(habitId);
             return 0;
           }
-          return t - 1;
+          // Persist remaining time on every tick
+          localStorage.setItem(storageKey, JSON.stringify({ timeLeft: next, finished: false }));
+          return next;
         });
       }, 1000);
     } else {
@@ -36,6 +76,7 @@ export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
     setRunning(false);
     setTimeLeft(WALK_DURATION);
     setFinished(false);
+    localStorage.setItem(storageKey, JSON.stringify({ timeLeft: WALK_DURATION, finished: false }));
   };
 
   const mm = String(Math.floor(timeLeft / 60)).padStart(2, "0");
@@ -50,7 +91,9 @@ export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
           <span className="hp-emoji">🌱</span>
           <div>
             <p className="hp-name">30-min walk or exercise</p>
-            <p className="hp-streak">{completionCount} total completion{completionCount !== 1 ? "s" : ""}</p>
+            <p className="hp-streak">
+              {completionCount} total completion{completionCount !== 1 ? "s" : ""}
+            </p>
           </div>
         </div>
         <div className="hp-card-actions">
@@ -64,15 +107,16 @@ export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
       {showPanel && (
         <div className="habit-panel walk-panel">
           <p className="panel-title">
-            {finished ? "🎉 Walk complete! Great job!" : running ? "Keep walking! You've got this 💪" : "Set your 30-minute walk timer"}
+            {finished
+              ? "🎉 Walk complete! Great job!"
+              : running
+              ? "Keep walking! You've got this 💪"
+              : "Set your 30-minute walk timer"}
           </p>
 
-          {/* Ring timer */}
           <div className="walk-timer-stage">
             <svg className="walk-ring-svg" viewBox="0 0 200 200">
-              {/* Background track */}
               <circle cx="100" cy="100" r="80" fill="none" stroke="#E8F5E9" strokeWidth="10" />
-              {/* Progress arc */}
               <circle
                 cx="100" cy="100" r="80"
                 fill="none"
@@ -84,11 +128,9 @@ export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
                 transform="rotate(-90 100 100)"
                 style={{ transition: "stroke-dashoffset 1s linear" }}
               />
-              {/* Walking figure */}
               <text x="100" y="88" textAnchor="middle" fontSize="32" className="walk-emoji-text">
                 {finished ? "🏆" : running ? "🚶" : "🧍"}
               </text>
-              {/* Time display */}
               <text x="100" y="118" textAnchor="middle" fontSize="22" fontWeight="700" fill="#1A1A1A" fontFamily="Poppins, sans-serif">
                 {mm}:{ss}
               </text>
@@ -98,7 +140,6 @@ export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
             </svg>
           </div>
 
-          {/* Stats row */}
           <div className="walk-stats-row">
             <div className="walk-stat">
               <span className="walk-stat-val">{Math.round(progress * 30)}</span>
@@ -114,9 +155,12 @@ export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
             </div>
           </div>
 
-          {/* Controls */}
           <div className="walk-controls">
-            <button className="med-btn med-btn--reset" onClick={reset} disabled={timeLeft === WALK_DURATION && !running}>
+            <button
+              className="med-btn med-btn--reset"
+              onClick={reset}
+              disabled={timeLeft === WALK_DURATION && !running}
+            >
               Reset
             </button>
             {!finished && (
@@ -128,7 +172,9 @@ export function WalkTimer({ habitId, logged, onToggleLog, completionCount }) {
               </button>
             )}
             {finished && (
-              <button className="med-btn med-btn--primary" onClick={reset}>Start Again</button>
+              <button className="med-btn med-btn--primary" onClick={reset}>
+                Start Again
+              </button>
             )}
           </div>
         </div>

--- a/src/pages/HabitsPage/habits/WaterTracker.jsx
+++ b/src/pages/HabitsPage/habits/WaterTracker.jsx
@@ -1,22 +1,39 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 const TOTAL_GLASSES = 8;
 
 export function WaterTracker({ habitId, logged, onToggleLog }) {
-  const [filled, setFilled] = useState(0);
+  const todayStr = new Date().toISOString().split("T")[0];
+  const storageKey = `water_tracker_${habitId}_${todayStr}`;
+
+  const [filled, setFilled] = useState(() => {
+    if (logged) return TOTAL_GLASSES;
+    const saved = localStorage.getItem(storageKey);
+    return saved ? parseInt(saved, 10) : 0;
+  });
 
   const [showPanel, setShowPanel] = useState(false);
+
+  useEffect(() => {
+    if (logged && filled < TOTAL_GLASSES) {
+      setFilled(TOTAL_GLASSES);
+      localStorage.setItem(storageKey, TOTAL_GLASSES);
+    } else if (!logged && filled === TOTAL_GLASSES) {
+      setFilled(0);
+      localStorage.setItem(storageKey, 0);
+    }
+  }, [logged, habitId, storageKey, filled]);
 
   const fill = (n) => {
     const next = filled === n ? n - 1 : n;
     setFilled(next);
+    localStorage.setItem(storageKey, next);
     if (next >= TOTAL_GLASSES && !logged) onToggleLog(habitId);
     if (next < TOTAL_GLASSES && logged) onToggleLog(habitId);
   };
 
   return (
     <div className="habit-panel-wrap">
-      {/* Card row */}
       <div
         className={`content-card hp-card${logged ? " content-card--active" : ""}`}
       >
@@ -40,7 +57,6 @@ export function WaterTracker({ habitId, logged, onToggleLog }) {
         </div>
       </div>
 
-      {/* Expandable panel */}
       {showPanel && (
         <div className="habit-panel water-panel">
           <p className="panel-title">Tap a glass to log it</p>
@@ -59,13 +75,9 @@ export function WaterTracker({ habitId, logged, onToggleLog }) {
           </div>
           <p className="water-progress-text">
             {filled === 0 && "Start drinking! Your body will thank you 💙"}
-            {filled > 0 &&
-              filled < 4 &&
-              `Good start! ${TOTAL_GLASSES - filled} more to go.`}
-            {filled >= 4 &&
-              filled < 8 &&
-              `Halfway there! ${TOTAL_GLASSES - filled} more glasses.`}
-            {filled === 8 && "🎉 Daily goal reached! Amazing!"}
+            {filled > 0 && filled < 4 && `Good start! ${TOTAL_GLASSES - filled} more to go.`}
+            {filled >= 4 && filled < 8 && `Halfway there! ${TOTAL_GLASSES - filled} more glasses.`}
+            {filled >= 8 && "🎉 Daily goal reached! Amazing!"}
           </p>
         </div>
       )}
@@ -76,7 +88,6 @@ export function WaterTracker({ habitId, logged, onToggleLog }) {
 export function GlassIcon({ filled }) {
   return (
     <svg viewBox="0 0 40 56" width="32" height="44" className="glass-svg">
-      {/* Glass outline */}
       <path
         d="M6 4 L10 52 L30 52 L34 4 Z"
         fill={filled ? "#BBDEFB" : "#F5F5F5"}
@@ -84,21 +95,13 @@ export function GlassIcon({ filled }) {
         strokeWidth="2"
         strokeLinejoin="round"
       />
-      {/* Water fill */}
       {filled && (
         <path d="M11 30 L10 52 L30 52 L29 30 Z" fill="#1E88E5" opacity="0.7" />
       )}
-      {/* Shine */}
       {filled && (
         <line
-          x1="14"
-          y1="34"
-          x2="14"
-          y2="48"
-          stroke="white"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          opacity="0.5"
+          x1="14" y1="34" x2="14" y2="48"
+          stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.5"
         />
       )}
     </svg>


### PR DESCRIPTION
## Problem
Partial habit progress (e.g. 5/8 glasses, 17 min into a walk, 2/3 meditation 
cycles) was stored only in React state, causing it to reset on every page refresh.

## Solution
Persists in-progress state to localStorage using date-scoped keys 
(e.g. `walk_timer_${habitId}_2026-05-09`), so progress survives refreshes 
and naturally resets at midnight without any DB changes.

## Changes
- `WaterTracker.jsx` — persists `filled` count on every glass tap
- `WalkTimer.jsx` — persists `{ timeLeft, finished }` on every timer tick
- `MorningMeditation.jsx` — persists completed `sessions` count after each cycle

## Notes
- No database schema changes required
- Full completion still writes to `habit_logs` as before
- All three components sync state if the `logged` prop changes externally