### PR TITLE
feat(ui): add skeleton LoadingPage and branded SigningInPage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import OnboardingPage from "./pages/OnboardingPage/OnboardingPage";
 import AuthCallback from "./pages/AuthCallback";
 import { supabase } from "./supabase";
 import SuspendedPage from "./pages/SuspendedPage/SuspendedPage";
-
+import LoadingPage from "./components/LoadingPage/LoadingPage";
 
 function App() {
   const [currentUser, setCurrentUser] = useState(null);
@@ -250,11 +250,11 @@ useEffect(() => {
               path="/suspended" 
               element={
                 !authReady ? (
-                  <div>Loading...</div>
+                  <LoadingPage />
                 ) : !currentUser ? (
                   <Navigate to="/login" replace />
                 ) : !profileReady ? (
-                  <div>Loading...</div>
+                  <LoadingPage />
                 ) : currentUser.role !== "suspended" ? (
                   <Navigate to="/home" replace />
                 ) : (
@@ -277,11 +277,11 @@ useEffect(() => {
           <Route
             element={
               !authReady ? (
-                <div>Loading...</div>
+                <LoadingPage />
               ) : !currentUser ? (
                 <Navigate to="/login" replace />
               ) : !profileReady ? (
-                <div>Loading...</div>
+                <LoadingPage />
               ) : currentUser.role === "suspended" ? (
                 <Navigate to="/suspended" replace />
               )

--- a/src/components/LoadingPage/LoadingPage.css
+++ b/src/components/LoadingPage/LoadingPage.css
@@ -1,0 +1,173 @@
+/* =============================================================================
+   LoadingPage.css — NEU MindSpace skeleton screen
+   Mirrors the MobileLayout shell: TopBar + Sidebar + Feed + BottomNav
+============================================================================= */
+
+/* Shell */
+.lp-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: #FAFAFA;
+  overflow: hidden;
+}
+
+/* ── Shimmer animation ─────────────────────────────────────────────────────── */
+.lp-skel {
+  background: linear-gradient(
+    90deg,
+    #E8E8E8 25%,
+    #F2F2F2 50%,
+    #E8E8E8 75%
+  );
+  background-size: 200% 100%;
+  animation: lp-shimmer 1.4s ease-in-out infinite;
+  border-radius: 6px;
+}
+
+@keyframes lp-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── Top Bar ───────────────────────────────────────────────────────────────── */
+.lp-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+  height: 60px;
+  background: #fff;
+  border-bottom: 1px solid #EBEBEB;
+  flex-shrink: 0;
+}
+
+.lp-logo   { width: 110px; height: 28px; border-radius: 6px; }
+.lp-search { flex: 1; max-width: 340px; height: 34px; border-radius: 20px; }
+.lp-avatar { width: 36px; height: 36px; border-radius: 50%; margin-left: auto; }
+
+/* ── Body ──────────────────────────────────────────────────────────────────── */
+.lp-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ── Sidebar ───────────────────────────────────────────────────────────────── */
+.lp-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  padding: 20px 16px;
+  background: #fff;
+  border-right: 1px solid #EBEBEB;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.lp-sidebar-label {
+  width: 70%;
+  height: 11px;
+  margin-bottom: 4px;
+  border-radius: 4px;
+}
+
+.lp-sidebar-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.lp-sidebar-icon { width: 20px; height: 20px; border-radius: 4px; flex-shrink: 0; }
+.lp-sidebar-text { height: 13px; flex: 1; border-radius: 4px; }
+
+/* ── Feed ──────────────────────────────────────────────────────────────────── */
+.lp-feed {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ── Post Card ─────────────────────────────────────────────────────────────── */
+.lp-card {
+  background: #fff;
+  border: 1px solid #EBEBEB;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.lp-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.lp-card-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.lp-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.lp-card-name { height: 13px; width: 40%; border-radius: 4px; }
+.lp-card-time { height: 11px; width: 25%; border-radius: 4px; }
+
+.lp-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lp-card-line { height: 13px; width: 100%; border-radius: 4px; }
+
+.lp-card-actions {
+  display: flex;
+  gap: 10px;
+  padding-top: 4px;
+  border-top: 1px solid #F2F2F2;
+}
+
+.lp-card-action-btn {
+  height: 28px;
+  width: 72px;
+  border-radius: 20px;
+}
+
+/* ── Bottom Nav (mobile only) ──────────────────────────────────────────────── */
+.lp-bottomnav {
+  display: none;
+  background: #fff;
+  border-top: 1px solid #EBEBEB;
+  padding: 8px 0 env(safe-area-inset-bottom, 8px);
+}
+
+.lp-bottomnav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+}
+
+.lp-bn-icon  { width: 24px; height: 24px; border-radius: 6px; }
+.lp-bn-label { width: 36px; height: 10px; border-radius: 4px; }
+
+/* ── Responsive ────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .lp-sidebar   { display: none; }
+  .lp-bottomnav { display: flex; }
+  .lp-feed      { padding: 16px 12px; }
+}

--- a/src/components/LoadingPage/LoadingPage.jsx
+++ b/src/components/LoadingPage/LoadingPage.jsx
@@ -1,0 +1,77 @@
+import './LoadingPage.css';
+
+export default function LoadingPage() {
+  return (
+    <div className="lp-shell">
+
+      {/* Top Bar Skeleton */}
+      <div className="lp-topbar">
+        <div className="lp-skel lp-logo" />
+        <div className="lp-skel lp-search" />
+        <div className="lp-skel lp-avatar" />
+      </div>
+
+      <div className="lp-body">
+
+        {/* Sidebar Skeleton */}
+        <aside className="lp-sidebar">
+          <div className="lp-skel lp-sidebar-label" />
+          {[1, 2, 3].map(i => (
+            <div className="lp-sidebar-item" key={i}>
+              <div className="lp-skel lp-sidebar-icon" />
+              <div className="lp-skel lp-sidebar-text" />
+            </div>
+          ))}
+
+          <div className="lp-skel lp-sidebar-label" style={{ marginTop: '1.5rem' }} />
+          {[1, 2].map(i => (
+            <div className="lp-sidebar-item" key={i + 10}>
+              <div className="lp-skel lp-sidebar-icon" />
+              <div className="lp-skel lp-sidebar-text" style={{ width: '55%' }} />
+            </div>
+          ))}
+        </aside>
+
+        {/* Feed Skeleton */}
+        <main className="lp-feed">
+          {[1, 2, 3].map(i => (
+            <div className="lp-card" key={i}>
+              {/* Card Header */}
+              <div className="lp-card-header">
+                <div className="lp-skel lp-card-avatar" />
+                <div className="lp-card-meta">
+                  <div className="lp-skel lp-card-name" />
+                  <div className="lp-skel lp-card-time" />
+                </div>
+              </div>
+
+              {/* Card Body Lines */}
+              <div className="lp-card-body">
+                <div className="lp-skel lp-card-line" />
+                <div className="lp-skel lp-card-line" style={{ width: '85%' }} />
+                <div className="lp-skel lp-card-line" style={{ width: '65%' }} />
+              </div>
+
+              {/* Card Actions */}
+              <div className="lp-card-actions">
+                <div className="lp-skel lp-card-action-btn" />
+                <div className="lp-skel lp-card-action-btn" />
+                <div className="lp-skel lp-card-action-btn" />
+              </div>
+            </div>
+          ))}
+        </main>
+      </div>
+
+      {/* Bottom Nav Skeleton (mobile) */}
+      <div className="lp-bottomnav">
+        {[1, 2, 3, 4].map(i => (
+          <div className="lp-bottomnav-item" key={i}>
+            <div className="lp-skel lp-bn-icon" />
+            <div className="lp-skel lp-bn-label" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { supabase } from '../supabase'
+import SigningInPage from './SigningInPage/SigningInPage'
 
 export default function AuthCallback() {
 
@@ -55,17 +56,5 @@ export default function AuthCallback() {
     return () => subscription.unsubscribe()
   }, [])
 
-  return (
-    <div style={{
-      minHeight: '100vh',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      fontFamily: "'Inter', sans-serif",
-      color: '#616161',
-      fontSize: '14px',
-    }}>
-      Signing you in…
-    </div>
-  )
+  return <SigningInPage />
 }

--- a/src/pages/SigningInPage/SigningInPage.css
+++ b/src/pages/SigningInPage/SigningInPage.css
@@ -1,0 +1,143 @@
+/* =============================================================================
+   SigningInPage.css — NEU MindSpace auth loading screen
+============================================================================= */
+
+.si-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #FAFAFA;
+  font-family: 'Inter', sans-serif;
+}
+
+.si-card {
+  background: #ffffff;
+  border: 1px solid #EBEBEB;
+  border-radius: 20px;
+  padding: 48px 40px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 300px;
+}
+
+/* ── Logo ──────────────────────────────────────────────────────────────────── */
+.si-logo-ring {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: #EAF3DE;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.si-logo-inner {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: #2E7D32;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Badge ─────────────────────────────────────────────────────────────────── */
+.si-badge {
+  background: #EAF3DE;
+  color: #27500A;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 4px 12px;
+  border-radius: 99px;
+  margin-bottom: 16px;
+  letter-spacing: 0.2px;
+}
+
+/* ── Text ──────────────────────────────────────────────────────────────────── */
+.si-title {
+  font-family: 'Poppins', 'Segoe UI', sans-serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: #1A1A1A;
+  margin: 0 0 6px;
+  letter-spacing: -0.3px;
+}
+
+.si-sub {
+  font-size: 14px;
+  color: #616161;
+  margin: 0 0 28px;
+}
+
+/* ── Dots ──────────────────────────────────────────────────────────────────── */
+.si-dots {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.si-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  animation: si-bounce 1.2s ease-in-out infinite;
+}
+
+.si-dot--green { background: #2E7D32; }
+.si-dot--gold  { background: #F5C400; animation-delay: 0.2s; }
+.si-dot--faded { background: #2E7D32; opacity: 0.4; animation-delay: 0.4s; }
+
+@keyframes si-bounce {
+  0%, 80%, 100% { transform: scale(0.65); opacity: 0.5; }
+  40%            { transform: scale(1);    opacity: 1;   }
+}
+
+/* ── Progress bar ──────────────────────────────────────────────────────────── */
+.si-bar-wrap {
+  width: 100%;
+  background: #F2F2F2;
+  border-radius: 99px;
+  height: 3px;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.si-bar {
+  height: 3px;
+  background: #2E7D32;
+  border-radius: 99px;
+  animation: si-slide 1.6s ease-in-out infinite;
+}
+
+@keyframes si-slide {
+  0%   { width: 0%;   margin-left: 0%; }
+  50%  { width: 65%;  margin-left: 17%; }
+  100% { width: 0%;   margin-left: 100%; }
+}
+
+/* ── Hint ──────────────────────────────────────────────────────────────────── */
+.si-hint {
+  font-size: 12px;
+  color: #BDBDBD;
+  margin: 0;
+}
+
+.si-logo-ring {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: #EAF3DE;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.si-logo-img {
+  width: 60px;
+  height: 60px;
+  object-fit: contain;
+}

--- a/src/pages/SigningInPage/SigningInPage.jsx
+++ b/src/pages/SigningInPage/SigningInPage.jsx
@@ -1,0 +1,36 @@
+import "./SigningInPage.css";
+
+export default function SigningInPage() {
+  return (
+    <div className="si-shell">
+      <div className="si-card">
+        {/* Logo */}
+        {/* Logo */}
+        <div className="si-logo-ring">
+          <img src="/NEULogo1.png" alt="NEU Logo" className="si-logo-img" />
+        </div>
+
+        {/* Badge */}
+        <span className="si-badge">New Era University</span>
+
+        {/* Title */}
+        <h1 className="si-title">MindSpace</h1>
+        <p className="si-sub">Signing you in…</p>
+
+        {/* Bouncing dots */}
+        <div className="si-dots">
+          <div className="si-dot si-dot--green" />
+          <div className="si-dot si-dot--gold" />
+          <div className="si-dot si-dot--faded" />
+        </div>
+
+        {/* Progress bar */}
+        <div className="si-bar-wrap">
+          <div className="si-bar" />
+        </div>
+
+        <p className="si-hint">Verifying your NEU account</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION

## Summary
Replaces bare loading states with polished, on-brand screens that give users visual feedback during auth resolution and the OAuth callback flow.

---

## Changes

### `SigningInPage` (new)
- Created `src/pages/SigningInPage/SigningInPage.jsx` and `SigningInPage.css`
- Displays a centered card with the NEU logo (`/NEULogo1.png`), MindSpace title, "New Era University" pill badge, and a "Verifying your NEU account" hint
- Animated bouncing dots (green / gold / faded-green) and a sliding progress bar using NEU brand tokens (`#2E7D32`, `#F5C400`)
- Used in `AuthCallback.jsx` — replaces the plain `Signing you in…` div

### `LoadingPage` (new)
- Created `src/pages/LoadingPage.jsx` and `LoadingPage.css`
- Full skeleton screen that mirrors the `MobileLayout` shell: top bar, sidebar, 3 post card skeletons, and a mobile bottom nav
- Skeleton blocks use a left-to-right shimmer animation (`#E8E8E8 → #F2F2F2`)
- Sidebar hidden and bottom nav shown on mobile (`≤768px`) to match the real layout
- Used in `App.jsx` — shown while `authReady` is `false` before routing resolves

### `AuthCallback.jsx`
- Swapped the inline loading div for `<SigningInPage />`

### `App.jsx`
- Swapped the inline loading div for `<LoadingPage />`

---

## Screenshots
> Attach screenshots of `SigningInPage` and `LoadingPage` here before merging.

---

## Testing
- [x] Hard refresh (`Ctrl + Shift + R`) shows `LoadingPage` briefly before routing
- [ ] Google OAuth flow shows `SigningInPage` during the callback
- [ ] Non-NEU account still redirects correctly to `/login?error=non_neu`
- [ ] Mobile view shows bottom nav skeleton, no sidebar
- [ ] No ESLint errors introduced