### PR TITLE
fix: resolve 404 on /auth/callback after OAuth redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Problem
Vercel was returning a 404 NOT_FOUND on `/auth/callback` after 
Google OAuth redirect because it was trying to serve a static file 
at that path instead of letting the React app handle it.

## Root Cause
Vite builds a SPA with a single `index.html` entry point. Without 
explicit rewrite rules, Vercel 404s on any route that isn't a real 
file — including `/auth/callback`.

## Fix
Added `vercel.json` with a catch-all rewrite that routes all paths 
to `index.html`, allowing React Router to handle client-side routing.

## Testing
- [ ] Google sign-in redirects correctly to `/auth/callback`
- [ ] Auth callback resolves and redirects to `/home`
- [ ] Non-NEU emails are rejected and redirected to `/login?error=non_neu`
- [ ] Direct navigation to other routes (e.g. `/home`, `/login`) still works