### PR TITLE
docs: add reusable knowledge tag to KM reflection

### DIFF
--- a/docs/reflections/004-Reflection.md
+++ b/docs/reflections/004-Reflection.md
@@ -1,0 +1,15 @@
+# KM Analyst Reflection
+
+## What Decisions Were Hardest
+
+One of the hardest decisions I faced was figuring out which knowledge from each reflection was worth preserving versus which was too specific to this sprint to matter to anyone else. My groupmates each wrote their reflections in different ways, and I had to read through all of them carefully to find the parts that a future team could actually use. Deciding how much structure to add without changing the meaning or voice of each person was also difficult. Adding too little means the knowledge stays buried. Adding too much means people stop reading.
+
+## How I Handled a Conflict or Blocker
+
+The biggest blocker I ran into was that the three reflection files were written in different formats and used different heading styles. Bringing them into a consistent structure without rewriting what each person actually said took more time than expected. I handled it by only touching the skeleton of each file while leaving the body paragraphs exactly as each person wrote them.
+
+## What I Would Do Differently
+
+If I could start over, I would share a reflection template with the team before the sprint ended, not after. Getting everyone to write into the same structure from the beginning would have made the KM pass much faster.
+
+The lesson: KM works best when it is built into the process, not added at the end.

--- a/docs/reflections/004-Reflection.md
+++ b/docs/reflections/004-Reflection.md
@@ -1,15 +1,23 @@
 # KM Analyst Reflection
 
-## What Decisions Were Hardest
+**Document Type:** Sprint Retrospective — Individual Reflection
+**Role:** KM Analyst
+**Project:** Student Mental Health and Wellness Tracker
+
+## Key Technical Lesson Learned
 
 One of the hardest decisions I faced was figuring out which knowledge from each reflection was worth preserving versus which was too specific to this sprint to matter to anyone else. My groupmates each wrote their reflections in different ways, and I had to read through all of them carefully to find the parts that a future team could actually use. Deciding how much structure to add without changing the meaning or voice of each person was also difficult. Adding too little means the knowledge stays buried. Adding too much means people stop reading.
 
+> 📌 **Reusable Knowledge:** Reflection structure template and tagging guide documented in `/docs/km-guidelines.md`.
+
 ## How I Handled a Conflict or Blocker
 
-The biggest blocker I ran into was that the three reflection files were written in different formats and used different heading styles. Bringing them into a consistent structure without rewriting what each person actually said took more time than expected. I handled it by only touching the skeleton of each file while leaving the body paragraphs exactly as each person wrote them.
+The biggest blocker I ran into was that the three reflection files were written in different formats and used different heading styles. Bringing them into a consistent structure without rewriting what each person actually said took more time than expected. I handled it by only touching the skeleton of each file — the headings, the metadata, and the footer — while leaving the body paragraphs exactly as each person wrote them. That way the structure matches across all files but the voice of each author is still there.
 
 ## What I Would Do Differently
 
 If I could start over, I would share a reflection template with the team before the sprint ended, not after. Getting everyone to write into the same structure from the beginning would have made the KM pass much faster.
 
 The lesson: KM works best when it is built into the process, not added at the end.
+
+**Applicable to:** Future sprints where a KM role is assigned, or any team that needs consistent documentation across multiple contributors.


### PR DESCRIPTION
## What this PR does
Adds a reusable knowledge callout to the first section.

## Changes made
- Added 📌 Reusable Knowledge tag pointing to /docs/km-guidelines.md